### PR TITLE
Add quick login links at top of page

### DIFF
--- a/rehearsal-room-frontend/src/components/Application.jsx
+++ b/rehearsal-room-frontend/src/components/Application.jsx
@@ -41,7 +41,16 @@ export default function App() {
             <Link to="/">Root</Link>
           </li>
           <li>
-            <Link to="/login">Login</Link>
+            <Link to="/login">Login page</Link>
+          </li>
+          <li>
+            <span>Quick login as:
+            <a onClick={() => setUserInfo("mabel.g@ythecultch.ca")}> Mabel</a> |
+            <a onClick={() => setUserInfo("dv1234@gmail.com")}> Declan</a> |
+            <a onClick={() => setUserInfo("the_man422@hotmail.com")}> Bob</a> |
+            <a onClick={() => setUserInfo("blue.steel@gmail.com")}> Zoolander</a> |
+            <a onClick={() => setUserInfo("petty_s123@gmail.com")}> Petunia</a> |
+            </span>
           </li>
           <li>
             <Link to="/register">Register</Link>


### PR DESCRIPTION
This adds 5 clickable names to the top of the page that you can select to immediately "log in" as that user. Hopefully should be useful for checking:

- logged-in vs logged-out functionality
- paths that send data from one user to another (i.e. requests)
- testing different data requests for each user (i.e. profile photos, booking data, spaces owned)